### PR TITLE
Fix flip clock digit alignment and remove extra text

### DIFF
--- a/countdown.html
+++ b/countdown.html
@@ -50,24 +50,17 @@
         }
 
         h1 {
-            font-size: clamp(2rem, 5vw, 4rem);
+            font-size: clamp(2.5rem, 6vw, 5rem);
             text-transform: uppercase;
-            letter-spacing: clamp(5px, 1vw, 10px);
-            margin-bottom: clamp(20px, 3vh, 40px);
+            letter-spacing: clamp(8px, 1.5vw, 15px);
+            margin-bottom: clamp(40px, 6vh, 80px);
             text-shadow: 0 0 20px #ff0000, 0 0 40px #ff0000;
             opacity: 0;
         }
 
-        .subtitle {
-            font-size: clamp(1rem, 2vw, 1.5rem);
-            margin-bottom: clamp(30px, 4vh, 60px);
-            opacity: 0;
-            color: #ff6666;
-        }
-
         .countdown {
             display: flex;
-            gap: clamp(20px, 4vw, 60px);
+            gap: clamp(25px, 5vw, 70px);
             justify-content: center;
             flex-wrap: wrap;
             align-items: center;
@@ -77,18 +70,18 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            gap: clamp(10px, 2vh, 20px);
+            gap: clamp(12px, 2.5vh, 25px);
         }
 
         .digits-group {
             display: flex;
-            gap: clamp(8px, 1vw, 15px);
+            gap: clamp(10px, 1.5vw, 20px);
         }
 
         .flip-card {
             perspective: 2000px;
-            width: clamp(60px, 10vw, 140px);
-            height: clamp(80px, 13vw, 180px);
+            width: clamp(70px, 12vw, 160px);
+            height: clamp(100px, 16vw, 220px);
             position: relative;
         }
 
@@ -114,9 +107,6 @@
             overflow: hidden;
             background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 100%);
             border: 2px solid #444;
-            display: flex;
-            align-items: center;
-            justify-content: center;
         }
 
         .digit-half.top {
@@ -134,7 +124,14 @@
         }
 
         .digit-value {
-            font-size: clamp(3rem, 8vw, 7rem);
+            position: absolute;
+            width: 100%;
+            top: 0;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: clamp(4rem, 10vw, 9rem);
             font-weight: bold;
             color: #ff0000;
             text-shadow: 0 0 15px rgba(255, 0, 0, 0.6);
@@ -143,11 +140,11 @@
         }
 
         .digit-half.top .digit-value {
-            transform: translateY(50%);
+            bottom: -100%;
         }
 
         .digit-half.bottom .digit-value {
-            transform: translateY(-50%);
+            top: -100%;
         }
 
         /* Flipping animation elements */
@@ -164,15 +161,30 @@
         }
 
         .flip-top-inner {
+            position: relative;
+            width: 100%;
             height: 200%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
             background: linear-gradient(180deg, #333 0%, #1a1a1a 100%);
             border: 2px solid #444;
             border-radius: clamp(8px, 1vw, 12px) clamp(8px, 1vw, 12px) 0 0;
             border-bottom: 1px solid #000;
             box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
+        }
+
+        .flip-top-inner .digit-value {
+            position: absolute;
+            width: 100%;
+            top: 0;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: clamp(4rem, 10vw, 9rem);
+            font-weight: bold;
+            color: #ff0000;
+            text-shadow: 0 0 15px rgba(255, 0, 0, 0.6);
+            line-height: 1;
+            user-select: none;
         }
 
         .flip-bottom {
@@ -188,41 +200,49 @@
         }
 
         .flip-bottom-inner {
+            position: relative;
+            width: 100%;
             height: 200%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
             background: linear-gradient(180deg, #1a1a1a 0%, #0a0a0a 100%);
             border: 2px solid #444;
             border-radius: 0 0 clamp(8px, 1vw, 12px) clamp(8px, 1vw, 12px);
             border-top: 1px solid #000;
             box-shadow: inset 0 -2px 5px rgba(0, 0, 0, 0.5);
-            transform: translateY(-100%);
+            transform: translateY(-50%);
+        }
+
+        .flip-bottom-inner .digit-value {
+            position: absolute;
+            width: 100%;
+            top: 0;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: clamp(4rem, 10vw, 9rem);
+            font-weight: bold;
+            color: #ff0000;
+            text-shadow: 0 0 15px rgba(255, 0, 0, 0.6);
+            line-height: 1;
+            user-select: none;
         }
 
         .time-label {
-            font-size: clamp(0.8rem, 1.5vw, 1.2rem);
+            font-size: clamp(0.9rem, 1.8vw, 1.4rem);
             text-transform: uppercase;
-            letter-spacing: clamp(2px, 0.5vw, 4px);
+            letter-spacing: clamp(2px, 0.6vw, 5px);
             color: #ff6666;
             opacity: 0;
-        }
-
-        .end-date {
-            margin-top: clamp(30px, 4vh, 60px);
-            font-size: clamp(1rem, 1.8vw, 1.3rem);
-            opacity: 0;
-            color: #ff3333;
-            text-shadow: 0 0 10px rgba(255, 0, 0, 0.5);
+            font-weight: bold;
         }
 
         @media (max-width: 600px) {
             .countdown {
-                gap: clamp(15px, 3vw, 30px);
+                gap: clamp(20px, 4vw, 40px);
             }
 
             .digits-group {
-                gap: clamp(5px, 1vw, 10px);
+                gap: clamp(6px, 1.2vw, 12px);
             }
         }
     </style>
@@ -232,7 +252,6 @@
 
     <div class="container">
         <h1 id="title">3 EXTRA POINTS</h1>
-        <div class="subtitle" id="subtitle">Time Remaining Until The End</div>
 
         <div class="countdown">
             <div class="time-section">
@@ -435,8 +454,6 @@
                 <div class="time-label">Seconds</div>
             </div>
         </div>
-
-        <div class="end-date" id="endDate">October 24, 2025 - 24:00</div>
     </div>
 
     <script>
@@ -493,12 +510,6 @@
                 easing: 'easeOutExpo'
             })
             .add({
-                targets: '#subtitle',
-                opacity: [0, 1],
-                duration: 800,
-                easing: 'easeOutExpo'
-            }, '-=500')
-            .add({
                 targets: '.time-section',
                 opacity: [0, 1],
                 scale: [0.8, 1],
@@ -512,13 +523,7 @@
                 duration: 600,
                 delay: anime.stagger(80),
                 easing: 'easeOutExpo'
-            }, '-=600')
-            .add({
-                targets: '#endDate',
-                opacity: [0, 1],
-                duration: 800,
-                easing: 'easeOutExpo'
-            }, '-=400');
+            }, '-=600');
 
         function flipDigit(digitId, newValue) {
             const topElement = document.getElementById(digitId);
@@ -575,8 +580,6 @@
                     document.getElementById(id).textContent = '0';
                     document.getElementById(id + '-bottom').textContent = '0';
                 });
-
-                document.getElementById('subtitle').textContent = 'THE TIME HAS COME';
 
                 // Dramatic animation when time is up
                 anime({


### PR DESCRIPTION
- Removed subtitle and end date text, keeping only "3 EXTRA POINTS" title
- Fixed digit alignment issue where top/bottom halves didn't meet properly
- Used absolute positioning with proper top/bottom offsets for perfect alignment
- Top half shows bottom: -100% to reveal top portion of number
- Bottom half shows top: -100% to reveal bottom portion of number
- Numbers now line up perfectly at the midsection
- Increased title and flip card sizes for better prominence
- Enhanced spacing and visual hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)